### PR TITLE
Add kamikaze functionality.

### DIFF
--- a/kale/sqs.py
+++ b/kale/sqs.py
@@ -86,3 +86,18 @@ class SQSTalk(object):
         :rtype: list[Queue]
         """
         return self._connection.get_all_queues(prefix)
+
+    def delete_queue(self, queue_name):
+        """Deletes a queue.
+
+        :param str queue_name: string for queue name.
+        :return: True if delete succeeded, False otherwise.
+        :rtype: bool
+        """
+        # Safety - Make sure queue is referenced locally.
+        if queue_name not in self._queues:
+            logger.error('Tried to delete unknown queue: %s' % queue_name)
+            return False
+
+        logger.info('Deleting queue %s' % queue_name)
+        return self._connection.delete_queue(queue_name)

--- a/kale/test_utils.py
+++ b/kale/test_utils.py
@@ -91,10 +91,16 @@ class TestQueueSelector(queue_selector.SelectQueueBase):
 
     def __init__(self, queue_info):
         self.queue_info = queue_info
+        self._index = 0
+        self._total_queues = len(self.queue_info.get_queues())
 
     def get_queue(self, *args, **kwargs):
         """Returns a TaskQueue object."""
-        return self.queue_info.get_queues()[0]
+        queue = self.queue_info.get_queues()[self._index]
+        self._index += 1
+        if self._index == self._total_queues:
+            self._index = 0
+        return queue
 
 
 def new_mock_message(task_class=None):


### PR DESCRIPTION
This'll allow for self-destructive task workers which will clean themselves and the queues that they're working with when the queues are empty.

This is useful when the task workers are not working on queues which will ever recieve new messages, but are just cleaning up older queues.

@wenbinf @niallo @mikhail @ashanbrown @kkaehler