### PR TITLE
Fixed the DIE_ON_RESIDENT_SET_SIZE_MB value

### DIFF
--- a/kale/worker.py
+++ b/kale/worker.py
@@ -197,7 +197,7 @@ class Worker(object):
         resource_data = resource.getrusage(resource.RUSAGE_SELF)
 
         if resource_data.ru_maxrss < (
-                settings.DIE_ON_RESIDENT_SET_SIZE_MB * 1024):
+                settings.DIE_ON_RESIDENT_SET_SIZE_MB * 1024 * 1024):
 
             if self._dirty:
                 # We only log when the worker has been infected by  tasks.


### PR DESCRIPTION
The comparison in kale/worker _check_process_resources() method
didn't work as intended, because the resource_data.ru_maxrss is
in bytes, but DIE_ON_RESIDENT_SET_SIZE_MB * 1024 is in KB. Just
added another 1024 to make it in MB.