### PR TITLE
use pycryptodome instead of pycrypto

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     test_suite='nose.collector',
     install_requires=[
         'boto',
-        'pycrypto',
+        'pycryptodome',
         'pyyaml',
         'setuptools',
         'six',


### PR DESCRIPTION
Reason:
https://nvd.nist.gov/vuln/detail/CVE-2013-7459

https://github.com/Legrandin/pycryptodome
```
a drop-in replacement for the old PyCrypto library. You install it with:

pip install pycryptodome
In this case, all modules are installed under the Crypto package.
```