### PR TITLE
Handle some SQS throttling more gracefully.

### DIFF
--- a/kale/queue_selector.py
+++ b/kale/queue_selector.py
@@ -105,7 +105,7 @@ class HighestPriorityFirst(SelectQueueBase):
     """
 
     def get_queue(self, *args, **kwargs):
-        queue = self.queue_info.get_highest_priority_non_empty_queue()
+        queue = self.queue_info.get_highest_priority_queue_that_needs_work()
         if queue:
             return queue
         queues = self.queue_info.get_queues()
@@ -121,7 +121,7 @@ class HighestPriorityLottery(Lottery):
     """
 
     def get_queue(self, *args, **kwargs):
-        queue = self.queue_info.get_highest_priority_non_empty_queue()
+        queue = self.queue_info.get_highest_priority_queue_that_needs_work()
         if queue:
             return queue
 
@@ -141,7 +141,7 @@ class LotteryLottery(Lottery):
 
         for i in range(retry_empty_queue_count):
             queue = self._run_lottery(self.queue_info.get_queues())
-            if not self.queue_info.is_queue_empty(queue):
+            if self.queue_info.does_queue_need_work(queue):
                 return queue
         return self._run_lottery(self.queue_info.get_queues())
 
@@ -162,7 +162,7 @@ class ReducedLottery(Lottery):
 
         while len(candidate_queues) > 0:
             queue = self._run_lottery(candidate_queues)
-            if not self.queue_info.is_queue_empty(queue):
+            if self.queue_info.does_queue_need_work(queue):
                 return queue
             else:
                 candidate_queues.remove(queue)

--- a/kale/scripts/benchmark_queue_info.py
+++ b/kale/scripts/benchmark_queue_info.py
@@ -41,7 +41,7 @@ class WorkerThread(threading.Thread):
     def run(self):
         for i in range(self.iterations):
             start_time = time.time()
-            self.queue_info_obj.get_highest_priority_non_empty_queue()
+            self.queue_info_obj.get_highest_priority_queue_that_needs_work()
             end_time = time.time()
             checking_sqs_time.put(end_time - start_time)
 

--- a/kale/scripts/benchmark_queue_selector.py
+++ b/kale/scripts/benchmark_queue_selector.py
@@ -140,7 +140,7 @@ class StaticQueueInfo(queue_info.QueueInfoBase):
                 return False
         return True
 
-    def get_highest_priority_non_empty_queue(self):
+    def get_highest_priority_queue_that_needs_work(self):
         """Returns a list of non-empty queues."""
         non_empty_queues = []
         for (queue_name, queue) in six.iteritems(self.queues):
@@ -157,6 +157,10 @@ class StaticQueueInfo(queue_info.QueueInfoBase):
         if not the_queue.tasks.empty():
             return False
         return True
+
+    def does_queue_need_work(self, queue):
+        """Checks if a queue should be worked on."""
+        return not self.is_queue_empty(queue)
 
 
 class WorkerThread(threading.Thread):

--- a/kale/tests/test_queue_selector.py
+++ b/kale/tests/test_queue_selector.py
@@ -13,12 +13,15 @@ class MultiQueueInfo(queue_info.QueueInfoBase):
                 queue_info.TaskQueue(name='queue2', priority=50),
                 queue_info.TaskQueue(name='queue3', priority=1)]
 
+    def does_queue_need_work(self, queue):
+        return not self.is_queue_empty(queue)
+
     def is_queue_empty(self, queue):
         if queue.name == 'queue2':
             return False
         return True
 
-    def get_highest_priority_non_empty_queue(self):
+    def get_highest_priority_queue_that_needs_work(self):
         return self.get_queues()[0]
 
 
@@ -33,7 +36,7 @@ class NoQueueInfo(queue_info.QueueInfoBase):
 
 
 class MultiQueueNoPriorityInfo(MultiQueueInfo):
-    def get_highest_priority_non_empty_queue(self):
+    def get_highest_priority_queue_that_needs_work(self):
         return None
 
 


### PR DESCRIPTION
Checking queue size seems to be throttled more aggressively than
other operations. Because we only use this check to prioritize
queues to pull messages from, assuming the queue has messages
should be a good strategy when we encounter this.

When a queue doesn't have messages, we will poll it for a few seconds
and move on to the next one.

I introduced a "queue needs work" concept so that we still have a
"queue is empty" concept that isn't fuzzy.