### PR TITLE
Add setting to specify pickle protocol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.5"
 
 install:
+  - pip install pycryptodome==3.6.1
   - python setup.py install
   - pip freeze
 

--- a/kale/default_settings.py
+++ b/kale/default_settings.py
@@ -2,9 +2,12 @@
 from __future__ import absolute_import
 
 import os
+import pickle
 import platform
 import time
 import zlib
+
+import six
 
 # The default settings are inadequate for actual use
 # due to the need for a queue. When the settings are
@@ -59,3 +62,10 @@ DIE_ON_RESIDENT_SET_SIZE_MB = 256
 
 # CIPHER used by kale.crypt, must be 16-, 24-, or 36-byte string
 UTIL_CRYPT_CIPHER = '1234567890123456'
+
+# If Python 2 & Python 3 need to co-exist, set PICKLE_PROTOCOL=2
+# Otherwise, this is protocol on Py2/Py3
+if six.PY2:
+    PICKLE_PROTOCOL = 0
+else:
+    PICKLE_PROTOCOL = pickle.DEFAULT_PROTOCOL

--- a/kale/default_settings.py
+++ b/kale/default_settings.py
@@ -63,8 +63,10 @@ DIE_ON_RESIDENT_SET_SIZE_MB = 256
 # CIPHER used by kale.crypt, must be 16-, 24-, or 36-byte string
 UTIL_CRYPT_CIPHER = '1234567890123456'
 
-# If Python 2 & Python 3 need to co-exist, set PICKLE_PROTOCOL=2
-# Otherwise, this is protocol on Py2/Py3
+# Manually specify pickle protocol used for writing Pickle files
+# Py2/Py3 have different default protocols. Reproduce those defaults
+# here for backwards compatibility.
+# Note: If Python 2 & Python 3 need to co-exist, override PICKLE_PROTOCOL=2
 if six.PY2:
     PICKLE_PROTOCOL = 0
 else:

--- a/kale/message.py
+++ b/kale/message.py
@@ -95,7 +95,7 @@ class KaleMessage(message.RawMessage):
         :rtype: str
         """
 
-        compressed_msg = _compressor(pickle.dumps(msg))
+        compressed_msg = _compressor(pickle.dumps(msg, protocol=settings.PICKLE_PROTOCOL))
         compressed_msg = crypt.encrypt(compressed_msg)
         # Check compressed task size.
         if len(compressed_msg) >= _task_size_limit:


### PR DESCRIPTION
Python 3 defaults to `protocol=3`, but the max protocol support by Python 2 is `2`. If Python 2 and Python 3 need to co-exist, then we need a way to ensure that Python 3 pickles in such a way that Python 2 can use it.