### PR TITLE
Change shutdown log statement to be a warning.

### DIFF
--- a/kale/worker.py
+++ b/kale/worker.py
@@ -220,7 +220,7 @@ class Worker(object):
         This will handle releasing tasks in flight and deleting tasks that have
         been completed.
         """
-        logger.info('Process sent signal %d. Cleaning up tasks...' % signum)
+        logger.warning('Process sent signal %d. Cleaning up tasks...' % signum)
 
         num_completed, num_incomplete = self._release_batch()
 


### PR DESCRIPTION
Since Kale is meant to run infinitely any shutdown is technically abnormal. A warning here is a perfect example of logging something that is abnormal but does not cause an error in the code. Warning level log statement will help track down issues when the engine shuts down in the middle of working on a single task.