### PR TITLE
Use region to specify message queue end point rather than proxy

### DIFF
--- a/kale/sqs.py
+++ b/kale/sqs.py
@@ -42,8 +42,11 @@ class SQSTalk(object):
             if settings.MESSAGE_QUEUE_USE_PROXY:
                 # Used only in Dev environment which uses ElasticMQ instead of
                 # SQS. Hence it uses a different boto api to connect to a proxy
-                region = boto.sqs.regioninfo.RegionInfo(name='elasticmq', endpoint=settings.MESSAGE_QUEUE_PROXY_PORT)
-                self._connections[conn_str] = boto.connect_sqs(aws_access_key_id=aws_access_key_id,
+                region = boto.sqs.regioninfo.RegionInfo(
+                    name='proxy',
+                    endpoint=settings.MESSAGE_QUEUE_PROXY_HOST)
+                self._connections[conn_str] = boto.connect_sqs(
+                    aws_access_key_id=aws_access_key_id,
                     aws_secret_access_key=aws_secret_access_key,
                     region=region,
                     is_secure=False,

--- a/kale/sqs.py
+++ b/kale/sqs.py
@@ -5,6 +5,7 @@ import logging
 
 import boto.sqs
 import boto.sqs.connection
+import boto.sqs.regioninfo
 
 from kale import exceptions
 from kale import message
@@ -41,12 +42,12 @@ class SQSTalk(object):
             if settings.MESSAGE_QUEUE_USE_PROXY:
                 # Used only in Dev environment which uses ElasticMQ instead of
                 # SQS. Hence it uses a different boto api to connect to a proxy
-                conn = boto.sqs.connection
-                self._connections[conn_str] = conn.SQSConnection(
-                    proxy_port=settings.MESSAGE_QUEUE_PROXY_PORT,
-                    proxy=settings.MESSAGE_QUEUE_PROXY_HOST, is_secure=False,
-                    aws_access_key_id=aws_access_key_id,
-                    aws_secret_access_key=aws_secret_access_key)
+                region = boto.sqs.regioninfo.RegionInfo(name='elasticmq', endpoint=settings.MESSAGE_QUEUE_PROXY_PORT)
+                self._connections[conn_str] = boto.connect_sqs(aws_access_key_id=aws_access_key_id,
+                    aws_secret_access_key=aws_secret_access_key,
+                    region=region,
+                    is_secure=False,
+                    port=settings.MESSAGE_QUEUE_PROXY_PORT)
             else:
                 # Used in staging and production
                 self._connections[conn_str] = boto.sqs.connect_to_region(


### PR DESCRIPTION
This change is part of the migration of nextdoor.com local dev environment from Docker to Kubernetes.  We are trying to expose K8s services to external users using Ambassador as the API gateway.  Part of that requires us to map services to urls one of which is elasticmq.localhost.com for the elasticmq service.  While testing Django routing, I could not get taskworker to work because Kale was unable to establish a sqs connection even after setting MESSAGE_QUEUE_PROXY_HOST to elasticmq.localhost.com and MESSAGE_QUEUE_PROXY_PORT to 80.  But setting region with the new elasticmq endpoint does work.