### PR TITLE
Allow tasks to delay when they are run

### DIFF
--- a/kale/task.py
+++ b/kale/task.py
@@ -89,8 +89,9 @@ class Task(object):
         return '%s_uuid_%s' % (cls.__name__, uuid.uuid1())
 
     @classmethod
-    def publish(cls, app_data, *args, delay_sec=None, **kwargs):
+    def publish(cls, app_data, *args, **kwargs):
         """Class method to publish a task given instance specific arguments."""
+        delay_sec = kwargs.get('delay_sec')
         task_id = cls._get_task_id(*args, **kwargs)
         payload = {
             'args': args,

--- a/kale/task.py
+++ b/kale/task.py
@@ -89,7 +89,7 @@ class Task(object):
         return '%s_uuid_%s' % (cls.__name__, uuid.uuid1())
 
     @classmethod
-    def publish(cls, app_data, *args, **kwargs):
+    def publish(cls, app_data, *args, delay_sec=None, **kwargs):
         """Class method to publish a task given instance specific arguments."""
         task_id = cls._get_task_id(*args, **kwargs)
         payload = {
@@ -97,7 +97,7 @@ class Task(object):
             'kwargs': kwargs,
             'app_data': app_data}
         pub = publisher.Publisher()
-        pub.publish(cls, task_id, payload)
+        pub.publish(cls, task_id, payload, delay_sec=delay_sec)
         return task_id
 
     @classmethod

--- a/kale/tests/test_queue_info.py
+++ b/kale/tests/test_queue_info.py
@@ -80,12 +80,12 @@ class QueueInfoTest(unittest.TestCase):
         return qinfo
 
     def test_queues(self):
-            qinfo = self._build_queue_info()
-            queues = qinfo.get_queues()
-            self.assertEquals(len(queues), 3)
+        qinfo = self._build_queue_info()
+        queues = qinfo.get_queues()
+        self.assertEquals(len(queues), 3)
 
-            # TODO (wenbin): add a separate test case for
-            # get_highest_priority_non_empty_queue.
+        # TODO (wenbin): add a separate test case for
+        # get_highest_priority_non_empty_queue.
 
     def test_not_implemented_ops(self):
         queue_info_base = queue_info.QueueInfoBase()

--- a/kale/tests/test_task.py
+++ b/kale/tests/test_task.py
@@ -85,7 +85,7 @@ class TaskFailureTestCase(unittest.TestCase):
         random_kwarg = 100
         payload = {
             'args': (random_arg,),
-            'kwargs': {'random_kwarg': random_kwarg},
+            'kwargs': {'random_kwarg': random_kwarg, 'delay_sec': delay_sec},
             'app_data': {}}
         with mock.patch(
                 'kale.publisher.Publisher.publish') as publish_func:

--- a/kale/tests/test_task.py
+++ b/kale/tests/test_task.py
@@ -78,6 +78,23 @@ class TaskFailureTestCase(unittest.TestCase):
             fail_func.assert_called_once_with(
                 message, exc, task.PERMANENT_FAILURE_UNRECOVERABLE, True)
 
+    def testDelayedPublish(self):
+        task_inst = test_utils.new_mock_task(task_class=test_utils.MockTask)
+        delay_sec = 60
+        random_arg = 99
+        random_kwarg = 100
+        payload = {
+            'args': (random_arg,),
+            'kwargs': {'random_kwarg': random_kwarg},
+            'app_data': {}}
+        with mock.patch(
+                'kale.publisher.Publisher.publish') as publish_func:
+            task_inst.publish({}, random_arg, delay_sec=delay_sec, random_kwarg=random_kwarg)
+            message = test_utils.MockMessage(task_inst)
+
+            publish_func.assert_called_once_with(test_utils.MockTask, message.task_id, payload,
+                                                 delay_sec=delay_sec)
+
     def testTaskNoRetries(self):
         """Task task failing with retries disabled."""
 


### PR DESCRIPTION
Expose delay_sec in Task's publish method so that clients can optionally declare a time delay until they should be run.

Kale already supports delayed tasks & uses this functionality when a task fails, to reschedule it to run some time later. This change just exposes this capability to users creating Tasks.