### PR TITLE
Change to accept delay_sec as 0 sec

### DIFF
--- a/kale/publisher.py
+++ b/kale/publisher.py
@@ -57,7 +57,7 @@ class Publisher(sqs.SQSTalk):
 
         sqs_queue.send_message(
             MessageBody=kale_msg.encode(),
-            DelaySeconds=delay_sec or 1
+            DelaySeconds=delay_sec or 0
         )
 
         logger.debug('Published task. Task id: %s; Task name: %s' % (


### PR DESCRIPTION
It is impossible to set `0` DelaySeconds (Execute Immediately) for `SendMessage` at `Publisher.publish()` because `delay_sec or 1` is recognized as `1` when `delay_sec == 0`.

`DelaySeconds` for `send_message()` does not accept `None` but only `int`. It is reasonable to check `delay_sec` is `None` or not by `or`.  But i think the fallback value should be `0`.
