### PR TITLE
Use pycryptodome 3.6.6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 before_install:
 - export BOTO_CONFIG=/dev/null
 install:
-- pip install pycryptodome==3.6.1
+- pip install pycryptodome==3.6.6
 - python setup.py install
 - pip freeze
 before_script:


### PR DESCRIPTION
We were pinned to 3.6.1 because of https://github.com/Legrandin/pycryptodome/issues/198, which is fixed in 3.6.6

We should also merge #55