### PR TITLE
Worker checks Task should_run_task to decide if it should execute run_task or republish with delay

### DIFF
--- a/kale/task.py
+++ b/kale/task.py
@@ -198,9 +198,6 @@ class Task(object):
         """
 
         self._setup_task_environment()
-        if not self.should_run_task(*args, **kwargs):
-            self.republish()
-            return
         self._pre_run(*args, **kwargs)
 
         try:

--- a/kale/task.py
+++ b/kale/task.py
@@ -164,7 +164,7 @@ class Task(object):
                 PERMANENT_FAILURE_RETRIES_EXCEEDED, False)
             return False
 
-        failure_count = message.failure_count
+        failure_count = message.task_failure_num
         if increment_failure_num:
             failure_count = failure_count + 1
         cls.republish(message, failure_count)

--- a/kale/test_utils.py
+++ b/kale/test_utils.py
@@ -29,6 +29,19 @@ class FailTask(task.Task):
         raise exceptions.TaskException('Task failed.')
 
 
+class ShouldNotRunTask(task.Task):
+
+    @classmethod
+    def _get_task_id(cls, *args, **kwargs):
+        return "should_not_run_task"
+
+    def should_run_task(self, *args, **kwargs):
+        return False
+
+    def run_task(self, *args, **kwargs):
+        pass
+
+
 class TimeoutTask(task.Task):
 
     @classmethod

--- a/kale/version.py
+++ b/kale/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '2.1.0'  # http://semver.org/
+__version__ = '2.2.0'  # http://semver.org/

--- a/kale/worker.py
+++ b/kale/worker.py
@@ -360,25 +360,30 @@ class Worker(object):
         :param time_remaining_sec: int seconds left for the batch of messages. Used mainly for logs
         """
         task_inst = message.task_inst
+
         try:
             with timeout.time_limit(task_inst.time_limit):
-                self.run_task(message)
-        except Exception as err:
-            # Re-publish failed tasks.
-            # As an optimization we could run all of the failures from a
-            # batch together.
-            permanent_failure = not task_inst.__class__.handle_failure(
-                message, err)
-            if permanent_failure and settings.USE_DEAD_LETTER_QUEUE:
-                self._permanent_failures.append(message)
+                if self.should_run_task(message):
+                    try:
+                        self.run_task(message)
+                    except Exception as err:
+                        # Re-publish failed tasks.
+                        # As an optimization we could run all of the failures from a
+                        # batch together.
+                        permanent_failure = not task_inst.__class__.handle_failure(
+                            message, err)
+                        if permanent_failure and settings.USE_DEAD_LETTER_QUEUE:
+                            self._permanent_failures.append(message)
 
-            self._failed_messages.append(message)
+                        self._failed_messages.append(message)
 
-            self._on_task_failed(message, time_remaining_sec, err,
-                                 permanent_failure)
-        else:
-            self._successful_messages.append(message)
-            self._on_task_succeeded(message, time_remaining_sec)
+                        self._on_task_failed(message, time_remaining_sec, err,
+                                             permanent_failure)
+                    else:
+                        self._successful_messages.append(message)
+                        self._on_task_succeeded(message, time_remaining_sec)
+                else:
+                    task_inst.__class__.republish(message, message.task_failure_num)
         finally:
             self.remove_message_or_exit(message)
         # Increment total messages counter.
@@ -390,6 +395,9 @@ class Worker(object):
         except ValueError:
             # Cleanup happened due to the signal handler - make sure we exit immediately.
             sys.exit(0)
+
+    def should_run_task(self, message):
+        return message.task_inst.should_run_task(*message.task_args, **message.task_kwargs)
 
     def run_task(self, message):
         """Run the task contained in the message.

--- a/kale/worker.py
+++ b/kale/worker.py
@@ -360,30 +360,28 @@ class Worker(object):
         :param time_remaining_sec: int seconds left for the batch of messages. Used mainly for logs
         """
         task_inst = message.task_inst
-
         try:
             with timeout.time_limit(task_inst.time_limit):
                 if not self.should_run_task(message):
                     task_inst.__class__.republish(message, message.task_failure_num)
                     return
-                try:
-                    self.run_task(message)
-                except Exception as err:
-                    # Re-publish failed tasks.
-                    # As an optimization we could run all of the failures from a
-                    # batch together.
-                    permanent_failure = not task_inst.__class__.handle_failure(
-                        message, err)
-                    if permanent_failure and settings.USE_DEAD_LETTER_QUEUE:
-                        self._permanent_failures.append(message)
+                self.run_task(message)
+        except Exception as err:
+            # Re-publish failed tasks.
+            # As an optimization we could run all of the failures from a
+            # batch together.
+            permanent_failure = not task_inst.__class__.handle_failure(
+                message, err)
+            if permanent_failure and settings.USE_DEAD_LETTER_QUEUE:
+                self._permanent_failures.append(message)
 
-                    self._failed_messages.append(message)
+            self._failed_messages.append(message)
 
-                    self._on_task_failed(message, time_remaining_sec, err,
-                                         permanent_failure)
-                else:
-                    self._successful_messages.append(message)
-                    self._on_task_succeeded(message, time_remaining_sec)
+            self._on_task_failed(message, time_remaining_sec, err,
+                                 permanent_failure)
+        else:
+            self._successful_messages.append(message)
+            self._on_task_succeeded(message, time_remaining_sec)
         finally:
             self.remove_message_or_exit(message)
         # Increment total messages counter.


### PR DESCRIPTION
Worker now allows Tasks to override should_run_task. The default behavior is to return True and execute run_task immediately after should_run_task. If a Task returns False, Worker will not execute run_task and republish the message with a delay. This allows API users to cancel the execution of a task without forcing them to raise an exception.