### PR TITLE
Drop python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-- '2.7'
 - '3.5'
 - '3.6'
 - '3.7'

--- a/kale/version.py
+++ b/kale/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '2.2.1'  # http://semver.org/
+__version__ = '3.0.0'  # http://semver.org/

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
 
@@ -42,21 +41,24 @@ class CleanHook(clean):
 
 # -*- Classifiers -*-
 
+
 classes = """
     Development Status :: 5 - Production/Stable
     License :: OSI Approved :: BSD License
     Topic :: System :: Distributed Computing
     Topic :: Software Development :: Object Brokering
     Programming Language :: Python
-    Programming Language :: Python
-    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: Implementation :: CPython
     Operating System :: OS Independent
 """
+
+
 classifiers = [s.strip() for s in classes.split('\n') if s]
+
 
 # -*- %%% -*-
 
@@ -72,6 +74,7 @@ setup(
     license='Apache License, Version 2',
     keywords='kale nextdoor taskworker sqs python',
     packages=['kale'],
+    python_requires=">=3.5",
     tests_require=[
         'mock==2.0.0',
         'nose==1.3.7',


### PR DESCRIPTION
Python 2 is no longer supported as of Jan 1, 2020.

https://github.com/python/devguide/pull/344