### PR TITLE
Add support for tagging SQS queues based upon queue name

### DIFF
--- a/kale/default_settings.py
+++ b/kale/default_settings.py
@@ -42,6 +42,8 @@ AWS_REGION = ''
 # Use max size (in bytes) as of March 2014 as the default.
 SQS_TASK_SIZE_LIMIT = 256000
 
+SQS_QUEUE_TAG_FUNCTION = lambda queue_name: {}
+
 RETRY_DELAY_MULTIPLE_SEC = 60
 SQS_MAX_TASK_DELAY_SEC = 900
 TIMESTAMP_FUNC = time.time

--- a/kale/sqs.py
+++ b/kale/sqs.py
@@ -55,6 +55,8 @@ class SQSTalk(object):
         self._client = self._session.client('sqs', endpoint_url=endpoint_url)
         self._sqs = self._session.resource('sqs', endpoint_url=endpoint_url)
 
+        self._sqs_queue_name_to_tag = settings.SQS_QUEUE_TAG_FUNCTION
+
     def _get_or_create_queue(self, queue_name):
         """Fetch or create a queue.
 
@@ -74,13 +76,14 @@ class SQSTalk(object):
         except botocore.exceptions.ClientError as e:
             if e.response['Error']['Code'] != 'AWS.SimpleQueueService.NonExistentQueue':
                 raise e
+            tags = self._get_sqs_queue_tags(queue_name)
 
             logger.info('Creating new SQS queue: %s' % queue_name)
-            queue = self._client.create_queue(QueueName=queue_name)
+            queue = self._client.create_queue(QueueName=queue_name, tags=tags)
             queue_url = queue.get('QueueUrl')
 
         # create queue object
-        queue = self._sqs.Queue(queue_url)
+        queue = self._sqs.Queue(queue_ukale/tests/test_settings.pyrl)
 
         self._queues[queue_name] = queue
         return queue
@@ -103,3 +106,17 @@ class SQSTalk(object):
             queues.append(self._sqs.Queue(queue_url))
 
         return queues
+
+    def _get_sqs_queue_tags(self, queue_name):
+        try:
+            tags = self._sqs_queue_name_to_tag(queue_name) or {}
+            if tags:
+                # Tags must be a Dict[str, str]
+                tags = {
+                    str(k): str(v)
+                    for k, v in tags.items()
+                }
+            return tags
+        except Exception as e:
+            logger.warning('Failed to extract SQS Queue tags %s' % queue_name, exc_info=True)
+            return {}

--- a/kale/tests/test_settings.py
+++ b/kale/tests/test_settings.py
@@ -8,3 +8,10 @@ QUEUE_CONFIG = os.path.join(os.path.split(os.path.abspath(__file__))[0],
 QUEUE_CLASS = 'kale.test_utils.TestQueueClass'
 QUEUE_SELECTOR = 'kale.test_utils.TestQueueSelector'
 AWS_REGION = 'us-east-1'
+
+
+def queue_name_to_tags(queue_name):
+    return {'is_dlq': 'dlq' in queue_name}
+
+
+SQS_QUEUE_TAG_FUNCTION = queue_name_to_tags

--- a/kale/tests/test_sqs.py
+++ b/kale/tests/test_sqs.py
@@ -31,13 +31,18 @@ class SQSTestCase(unittest.TestCase):
 
         sqs_inst._get_or_create_queue('LowPriorityTest1')
         sqs_inst._get_or_create_queue('HighPriorityTest2')
+        sqs_inst._get_or_create_queue('HighPriorityTest2-dlq')
 
         expected_low_queue = sqs_inst._sqs.Queue('https://queue.amazonaws.com/123456789012/'
                                                  'LowPriorityTest1')
         expected_hi_queue = sqs_inst._sqs.Queue('https://queue.amazonaws.com/123456789012/'
                                                 'HighPriorityTest2')
 
-        self.assertEqual(len(sqs_inst._queues), 2)
+        expected_hi_dlq_queue = sqs_inst._sqs.Queue('https://queue.amazonaws.com/123456789012/'
+                                                'HighPriorityTest2-dlq')
+
+
+        self.assertEqual(len(sqs_inst._queues), 3)
 
         self.assertEqual(expected_low_queue, sqs_inst._queues['LowPriorityTest1'])
         self.assertEqual(expected_hi_queue, sqs_inst._queues['HighPriorityTest2'])


### PR DESCRIPTION
This is a slightly different approach than I was originally planning, but I think it may be simpler. This allows consumers to specify a function which extracts tags from the queue name. E.g. in our case, flavor, release, dlq status, etc. 